### PR TITLE
fix: make marquee loop seamless

### DIFF
--- a/packages/doc/src/pages/index.astro
+++ b/packages/doc/src/pages/index.astro
@@ -4,6 +4,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 const baseUrl = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const signalMessages = [
+  '給城市一個清楚的字',
+  'Make room for meaning',
+  '為每種閱讀距離而生',
+];
 ---
 
 <BaseLayout>
@@ -63,11 +68,14 @@ const baseUrl = import.meta.env.BASE_URL.endsWith('/')
     </section>
 
     <section class="signal-strip" aria-label="字型宣言">
-      <div class="signal-track">
-        <span>給城市一個清楚的字</span><span aria-hidden="true">✳</span>
-        <span>Make room for meaning</span><span aria-hidden="true">✳</span>
-        <span>為每種閱讀距離而生</span><span aria-hidden="true">✳</span>
-        <span>給城市一個清楚的字</span><span aria-hidden="true">✳</span>
+      <div class="signal-track" data-signal-track aria-hidden="true">
+        <div class="signal-sequence" data-signal-copy="original" data-signal-sequence>
+          {signalMessages.map((message) => (
+            <>
+              <span>{message}</span><span>✳</span>
+            </>
+          ))}
+        </div>
       </div>
     </section>
 

--- a/packages/doc/src/scripts/site.ts
+++ b/packages/doc/src/scripts/site.ts
@@ -10,6 +10,8 @@ const sizeOutput = document.querySelector<HTMLOutputElement>('[data-size-output]
 const weightOutput = document.querySelector<HTMLOutputElement>('[data-weight-output]');
 const heroStage = document.querySelector<HTMLElement>('[data-hero-stage]');
 const revealItems = document.querySelectorAll<HTMLElement>('[data-reveal]');
+const signalTrack = document.querySelector<HTMLElement>('[data-signal-track]');
+const signalSequence = document.querySelector<HTMLElement>('[data-signal-sequence]');
 
 const setTheme = (theme: Theme): void => {
   root.dataset['theme'] = theme;
@@ -43,6 +45,33 @@ const updateSpecimen = (): void => {
 sizeInput?.addEventListener('input', updateSpecimen);
 weightInput?.addEventListener('input', updateSpecimen);
 updateSpecimen();
+
+const updateSignalMarquee = (): void => {
+  if (!signalTrack || !signalSequence) return;
+
+  const sequenceWidth = signalSequence.getBoundingClientRect().width;
+  if (!sequenceWidth) return;
+
+  const copyCount = Math.max(2, Math.ceil(window.innerWidth / sequenceWidth) + 1);
+  const copies = Array.from(
+    signalTrack.querySelectorAll<HTMLElement>('[data-signal-copy]'),
+  );
+
+  copies.slice(copyCount).forEach((copy) => copy.remove());
+  for (let index = copies.length; index < copyCount; index += 1) {
+    const copy = signalSequence.cloneNode(true) as HTMLElement;
+    copy.dataset['signalCopy'] = 'duplicate';
+    copy.removeAttribute('data-signal-sequence');
+    signalTrack.append(copy);
+  }
+
+  signalTrack.style.setProperty('--signal-distance', `${sequenceWidth}px`);
+  signalTrack.classList.add('is-ready');
+};
+
+updateSignalMarquee();
+window.addEventListener('resize', updateSignalMarquee);
+if (document.fonts) document.fonts.ready.then(updateSignalMarquee);
 
 if (heroStage) {
   heroStage.addEventListener('pointermove', (event: PointerEvent) => {

--- a/packages/doc/src/styles/global.css
+++ b/packages/doc/src/styles/global.css
@@ -489,17 +489,32 @@ h3 > span,
   display: flex;
   width: max-content;
   align-items: center;
-  gap: 2.5rem;
   padding: 1rem 0;
   font-family: var(--font-specimen);
   font-size: clamp(1rem, 2vw, 1.4rem);
   white-space: nowrap;
-  animation: marquee 24s linear infinite;
 }
 
-.signal-track span:nth-child(even) {
+.signal-track.is-ready {
+  animation: signal-marquee 24s linear infinite;
+}
+
+.signal-sequence {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 2.5rem;
+  width: max-content;
+  padding-right: 2.5rem;
+}
+
+.signal-sequence span:nth-child(even) {
   font-family: var(--font-ui);
   font-size: 0.75rem;
+}
+
+.signal-strip:hover .signal-track {
+  animation-play-state: paused;
 }
 
 .section {
@@ -986,9 +1001,9 @@ pre {
   }
 }
 
-@keyframes marquee {
+@keyframes signal-marquee {
   to {
-    transform: translateX(-25%);
+    transform: translate3d(calc(-1 * var(--signal-distance)), 0, 0);
   }
 }
 
@@ -1100,5 +1115,26 @@ pre {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .signal-strip {
+    overflow: visible;
+  }
+
+  .signal-track {
+    width: 100%;
+    animation-name: none !important;
+    white-space: normal;
+  }
+
+  .signal-sequence {
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding-right: 0;
+  }
+
+  .signal-sequence[data-signal-copy='duplicate'] {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary

- measure the rendered marquee sequence and add only the copies required by the current viewport
- translate exactly one sequence width for a seamless loop
- keep spacing uniform at every separator and provide a static reduced-motion fallback

## Root cause

The previous track shifted by a percentage that did not align with the variable-width message sequence. Its viewport-width padding also created a visibly oversized gap at the seam.

## Validation

- `pnpm --filter doc check`
- `pnpm --filter doc build`
- verified the running site in a browser at the desktop viewport, including the animated seam and reduced-motion fallback